### PR TITLE
Fixed wrong link

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -122,7 +122,7 @@
         <div style="width: fit-content;margin-left: auto;margin-right: auto;">
           <a href="https://github.com/RedstoneParadox"><img src="images/social/github.svg" class="social-icon" style="width:28px;height:28px;margin: 8px;"></a>
           <a href="https://www.youtube.com/@redstoneparadox"><img src="images/social/youtube.svg" class="social-icon" style="width:28px;height:28px;margin: 8px;"></a>
-          <a href="https://github.com/RedstoneParadox"><img src="images/social/modrinth.svg" class="social-icon" style="width:28px;height:28px;margin: 8px;"></a>
+          <a href="https://modrinth.com/user/RedstoneParadox"><img src="images/social/modrinth.svg" class="social-icon" style="width:28px;height:28px;margin: 8px;"></a>
           <a href="https://discord.gg/crZpcjtdJR"><img src="images/social/discord.svg" class="social-icon" style="width:28px;height:28px;margin: 8px;"></a>
         </div>
       </div>


### PR DESCRIPTION
Clicking the modrinth icon now links to modrinth, not GH